### PR TITLE
Fixed a display blink on DisplayedChildAttribute

### DIFF
--- a/robobinding/src/main/java/org/robobinding/widget/viewanimator/DisplayedChildAttribute.java
+++ b/robobinding/src/main/java/org/robobinding/widget/viewanimator/DisplayedChildAttribute.java
@@ -14,6 +14,8 @@ public class DisplayedChildAttribute implements PropertyViewAttribute<ViewAnimat
     
     @Override
     public void updateView(ViewAnimator view, Integer newValue) {
-	view.setDisplayedChild(newValue);
+        if (view.getDisplayedChild() != newValue) {
+            view.setDisplayedChild(newValue);
+        }
     }
 }


### PR DESCRIPTION
Fixed a display blink when calling setDisplayedChild() with the same value.
