### PR TITLE
DataSetProperties not detected in ItemPresentationModel

### DIFF
--- a/codegen/src/main/java/org/robobinding/codegen/processor/PresentationModelProcessor.java
+++ b/codegen/src/main/java/org/robobinding/codegen/processor/PresentationModelProcessor.java
@@ -104,7 +104,7 @@ public class PresentationModelProcessor extends AbstractProcessor {
 			TypeElementWrapper typeElement = context.TypeElementOf(info.itemPresentationModelTypeName());
 			
 			PresentationModelInfoBuilder builder = new PresentationModelInfoBuilder(
-					typeElement, info.itemPresentationModelObjectTypeName(), false);
+					typeElement, info.itemPresentationModelObjectTypeName(), true);
 			PresentationModelInfo itemPresentationModelInfo = builder.build();
 			try {
 				ItemPresentationModelObjectClassGen gen = new ItemPresentationModelObjectClassGen(itemPresentationModelInfo);


### PR DESCRIPTION
I have a class that implements `ItemPresentationModel` but also have a property annotated with `@ItemPresentationModel`.

That property isn't detected as DataSetProperty (`source: No such dataSet property` error is thown). This PR fixes this.
