### PR TITLE
#238: item view preinitialization by default, with possibility to override by @DoNotPreinitialize

### DIFF
--- a/framework/src/main/java/org/robobinding/annotation/DoNotPreinitialize.java
+++ b/framework/src/main/java/org/robobinding/annotation/DoNotPreinitialize.java
@@ -1,0 +1,21 @@
+package org.robobinding.annotation;
+
+import org.robobinding.itempresentationmodel.ItemPresentationModel;
+import org.robobinding.presentationmodel.PresentationModelChangeSupport;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used on {@link ItemPresentationModel} implementation to prevent preinitialization of item's view.
+ * In such case, the implementation should have change support and take care of calling
+ * {@link PresentationModelChangeSupport#refreshPresentationModel()} when needed.
+ *
+ * @author Zbigniew Malinowski
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DoNotPreinitialize {
+}

--- a/framework/src/main/java/org/robobinding/widget/adapterview/DataSetAdapter.java
+++ b/framework/src/main/java/org/robobinding/widget/adapterview/DataSetAdapter.java
@@ -1,6 +1,7 @@
 package org.robobinding.widget.adapterview;
 
 import org.robobinding.BindableView;
+import org.robobinding.annotation.DoNotPreinitialize;
 import org.robobinding.itempresentationmodel.ItemContext;
 import org.robobinding.itempresentationmodel.RefreshableItemPresentationModel;
 import org.robobinding.presentationmodel.AbstractPresentationModelObject;
@@ -13,115 +14,117 @@ import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 
 /**
- * 
- * @since 1.0
  * @author Cheng Wei
  * @author Robert Taylor
+ * @since 1.0
  */
 public class DataSetAdapter extends BaseAdapter {
-	private enum DisplayType {
-		ITEM_LAYOUT, DROPDOWN_LAYOUT
-	}
+    private enum DisplayType {
+        ITEM_LAYOUT, DROPDOWN_LAYOUT
+    }
 
-	private final DataSetValueModel dataSetValueModel;
+    private final DataSetValueModel dataSetValueModel;
 
-	private final ItemLayoutBinder itemLayoutBinder;
-	private final ItemLayoutBinder dropdownLayoutBinder;
-	private final ItemLayoutSelector itemLayoutSelector;
-	private final int dropdownLayoutId;
-	private final ViewTags<RefreshableItemPresentationModel> viewTags;
+    private final ItemLayoutBinder itemLayoutBinder;
+    private final ItemLayoutBinder dropdownLayoutBinder;
+    private final ItemLayoutSelector itemLayoutSelector;
+    private final int dropdownLayoutId;
+    private final ViewTags<RefreshableItemPresentationModel> viewTags;
 
-	private final boolean preInitializeViews;
+    public DataSetAdapter(DataSetValueModel dataSetValueModel,
+                          ItemLayoutBinder itemLayoutBinder, ItemLayoutBinder dropdownLayoutBinder,
+                          ItemLayoutSelector itemLayoutSelector, int dropdownLayoutId,
+                          ViewTags<RefreshableItemPresentationModel> viewTags) {
 
-	public DataSetAdapter(DataSetValueModel dataSetValueModel, 
-			ItemLayoutBinder itemLayoutBinder, ItemLayoutBinder dropdownLayoutBinder, 
-			ItemLayoutSelector itemLayoutSelector, int dropdownLayoutId,
-			ViewTags<RefreshableItemPresentationModel> viewTags, boolean preInitializeViews) {
-		this.preInitializeViews = preInitializeViews;
-		
-		this.dataSetValueModel = dataSetValueModel;
-		this.itemLayoutBinder = itemLayoutBinder;
-		this.dropdownLayoutBinder = dropdownLayoutBinder;
-		this.itemLayoutSelector = itemLayoutSelector;
-		this.dropdownLayoutId = dropdownLayoutId;
-		this.viewTags = viewTags;
-	}
+        this.dataSetValueModel = dataSetValueModel;
+        this.itemLayoutBinder = itemLayoutBinder;
+        this.dropdownLayoutBinder = dropdownLayoutBinder;
+        this.itemLayoutSelector = itemLayoutSelector;
+        this.dropdownLayoutId = dropdownLayoutId;
+        this.viewTags = viewTags;
+    }
 
-	@Override
-	public int getCount() {
-		return dataSetValueModel.size();
-	}
+    @Override
+    public int getCount() {
+        return dataSetValueModel.size();
+    }
 
-	@Override
-	public Object getItem(int position) {
-		return dataSetValueModel.get(position);
-	}
+    @Override
+    public Object getItem(int position) {
+        return dataSetValueModel.get(position);
+    }
 
-	@Override
-	public long getItemId(int position) {
-		return position;
-	}
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
 
-	@Override
-	public View getView(int position, View convertView, ViewGroup parent) {
-		return createViewFromResource(position, convertView, parent, DisplayType.ITEM_LAYOUT);
-	}
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        return createViewFromResource(position, convertView, parent, DisplayType.ITEM_LAYOUT);
+    }
 
-	@Override
-	public View getDropDownView(int position, View convertView, ViewGroup parent) {
-		return createViewFromResource(position, convertView, parent, DisplayType.DROPDOWN_LAYOUT);
-	}
+    @Override
+    public View getDropDownView(int position, View convertView, ViewGroup parent) {
+        return createViewFromResource(position, convertView, parent, DisplayType.DROPDOWN_LAYOUT);
+    }
 
-	private View createViewFromResource(int position, View convertView, ViewGroup parent, DisplayType displayType) {
-		if (convertView == null) {
-			return newView(position, parent, displayType);
-		} else {
-			updateItemPresentationModel(convertView, position);
-			return convertView;
-		}
-	}
+    private View createViewFromResource(int position, View convertView, ViewGroup parent, DisplayType displayType) {
+        if (convertView == null) {
+            return newView(position, parent, displayType);
+        } else {
+            updateItemPresentationModel(convertView, position);
+            return convertView;
+        }
+    }
 
-	private View newView(int position, ViewGroup parent, DisplayType displayType) {
-		BindableView bindableView;
-		Object item = getItem(position);
-		if (displayType == DisplayType.ITEM_LAYOUT) {
-			int layoutId = itemLayoutSelector.selectLayout(getItemViewType(position));
-			bindableView = itemLayoutBinder.inflate(parent, layoutId);
-		} else {
-			bindableView = dropdownLayoutBinder.inflate(parent, dropdownLayoutId);
-		}
-		
-		View view = bindableView.getRootView();
-		RefreshableItemPresentationModel itemPresentationModel = dataSetValueModel.newRefreshableItemPresentationModel(
-				getItemViewType(position));
-		itemPresentationModel.updateData(item, new ItemContext(view, position));
-		bindableView.bindTo((AbstractPresentationModelObject)itemPresentationModel);
+    private View newView(int position, ViewGroup parent, DisplayType displayType) {
+        BindableView bindableView;
+        Object item = getItem(position);
+        if (displayType == DisplayType.ITEM_LAYOUT) {
+            int layoutId = itemLayoutSelector.selectLayout(getItemViewType(position));
+            bindableView = itemLayoutBinder.inflate(parent, layoutId);
+        } else {
+            bindableView = dropdownLayoutBinder.inflate(parent, dropdownLayoutId);
+        }
 
-		ViewTag<RefreshableItemPresentationModel> viewTag = viewTags.tagFor(view);
-		viewTag.set(itemPresentationModel);
-		return view;
-	}
+        View view = bindableView.getRootView();
+        RefreshableItemPresentationModel itemPresentationModel = dataSetValueModel.newRefreshableItemPresentationModel(
+                getItemViewType(position));
+        bindableView.bindTo((AbstractPresentationModelObject) itemPresentationModel);
+        itemPresentationModel.updateData(item, new ItemContext(view, position));
+        refreshIfRequired(itemPresentationModel);
 
-	private void updateItemPresentationModel(View view, int position) {
-		ViewTag<RefreshableItemPresentationModel> viewTag = viewTags.tagFor(view);
-		RefreshableItemPresentationModel itemPresentationModel = viewTag.get();
-		itemPresentationModel.updateData(getItem(position), new ItemContext(view, position));
-		refreshIfRequired(itemPresentationModel);
-	}
-	
-	private void refreshIfRequired(RefreshableItemPresentationModel itemPresentationModel) {
-		if(preInitializeViews) {
-			itemPresentationModel.refresh();
-		}
-	}
-	
-	@Override
-	public int getViewTypeCount() {
-		return itemLayoutSelector.getViewTypeCount();
-	}
-	
-	@Override
-	public int getItemViewType(int position) {
-		return itemLayoutSelector.getItemViewType(getItem(position), position);
-	}
+        ViewTag<RefreshableItemPresentationModel> viewTag = viewTags.tagFor(view);
+        viewTag.set(itemPresentationModel);
+        return view;
+    }
+
+    private boolean isPreinitializable(RefreshableItemPresentationModel itemPresentationModel) {
+        final Class<?> presentationModelClass = ((AbstractPresentationModelObject) itemPresentationModel).getPresentationModelClass();
+        return !presentationModelClass.isAnnotationPresent(DoNotPreinitialize.class);
+    }
+
+    private void updateItemPresentationModel(View view, int position) {
+        ViewTag<RefreshableItemPresentationModel> viewTag = viewTags.tagFor(view);
+        RefreshableItemPresentationModel itemPresentationModel = viewTag.get();
+        itemPresentationModel.updateData(getItem(position), new ItemContext(view, position));
+        refreshIfRequired(itemPresentationModel);
+    }
+
+    private void refreshIfRequired(RefreshableItemPresentationModel itemPresentationModel) {
+        if (isPreinitializable(itemPresentationModel)) {
+            itemPresentationModel.refresh();
+        }
+    }
+
+    @Override
+    public int getViewTypeCount() {
+        return itemLayoutSelector.getViewTypeCount();
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        return itemLayoutSelector.getItemViewType(getItem(position), position);
+    }
 }

--- a/framework/src/main/java/org/robobinding/widget/adapterview/DataSetAdapter.java
+++ b/framework/src/main/java/org/robobinding/widget/adapterview/DataSetAdapter.java
@@ -19,112 +19,112 @@ import android.widget.BaseAdapter;
  * @since 1.0
  */
 public class DataSetAdapter extends BaseAdapter {
-    private enum DisplayType {
-        ITEM_LAYOUT, DROPDOWN_LAYOUT
-    }
+	private enum DisplayType {
+		ITEM_LAYOUT, DROPDOWN_LAYOUT
+	}
 
-    private final DataSetValueModel dataSetValueModel;
+	private final DataSetValueModel dataSetValueModel;
 
-    private final ItemLayoutBinder itemLayoutBinder;
-    private final ItemLayoutBinder dropdownLayoutBinder;
-    private final ItemLayoutSelector itemLayoutSelector;
-    private final int dropdownLayoutId;
-    private final ViewTags<RefreshableItemPresentationModel> viewTags;
+	private final ItemLayoutBinder itemLayoutBinder;
+	private final ItemLayoutBinder dropdownLayoutBinder;
+	private final ItemLayoutSelector itemLayoutSelector;
+	private final int dropdownLayoutId;
+	private final ViewTags<RefreshableItemPresentationModel> viewTags;
 
-    public DataSetAdapter(DataSetValueModel dataSetValueModel,
-                          ItemLayoutBinder itemLayoutBinder, ItemLayoutBinder dropdownLayoutBinder,
-                          ItemLayoutSelector itemLayoutSelector, int dropdownLayoutId,
-                          ViewTags<RefreshableItemPresentationModel> viewTags) {
+	public DataSetAdapter(DataSetValueModel dataSetValueModel,
+						  ItemLayoutBinder itemLayoutBinder, ItemLayoutBinder dropdownLayoutBinder,
+						  ItemLayoutSelector itemLayoutSelector, int dropdownLayoutId,
+						  ViewTags<RefreshableItemPresentationModel> viewTags) {
 
-        this.dataSetValueModel = dataSetValueModel;
-        this.itemLayoutBinder = itemLayoutBinder;
-        this.dropdownLayoutBinder = dropdownLayoutBinder;
-        this.itemLayoutSelector = itemLayoutSelector;
-        this.dropdownLayoutId = dropdownLayoutId;
-        this.viewTags = viewTags;
-    }
+		this.dataSetValueModel = dataSetValueModel;
+		this.itemLayoutBinder = itemLayoutBinder;
+		this.dropdownLayoutBinder = dropdownLayoutBinder;
+		this.itemLayoutSelector = itemLayoutSelector;
+		this.dropdownLayoutId = dropdownLayoutId;
+		this.viewTags = viewTags;
+	}
 
-    @Override
-    public int getCount() {
-        return dataSetValueModel.size();
-    }
+	@Override
+	public int getCount() {
+		return dataSetValueModel.size();
+	}
 
-    @Override
-    public Object getItem(int position) {
-        return dataSetValueModel.get(position);
-    }
+	@Override
+	public Object getItem(int position) {
+		return dataSetValueModel.get(position);
+	}
 
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
+	@Override
+	public long getItemId(int position) {
+		return position;
+	}
 
-    @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
-        return createViewFromResource(position, convertView, parent, DisplayType.ITEM_LAYOUT);
-    }
+	@Override
+	public View getView(int position, View convertView, ViewGroup parent) {
+		return createViewFromResource(position, convertView, parent, DisplayType.ITEM_LAYOUT);
+	}
 
-    @Override
-    public View getDropDownView(int position, View convertView, ViewGroup parent) {
-        return createViewFromResource(position, convertView, parent, DisplayType.DROPDOWN_LAYOUT);
-    }
+	@Override
+	public View getDropDownView(int position, View convertView, ViewGroup parent) {
+		return createViewFromResource(position, convertView, parent, DisplayType.DROPDOWN_LAYOUT);
+	}
 
-    private View createViewFromResource(int position, View convertView, ViewGroup parent, DisplayType displayType) {
-        if (convertView == null) {
-            return newView(position, parent, displayType);
-        } else {
-            updateItemPresentationModel(convertView, position);
-            return convertView;
-        }
-    }
+	private View createViewFromResource(int position, View convertView, ViewGroup parent, DisplayType displayType) {
+		if (convertView == null) {
+			return newView(position, parent, displayType);
+		} else {
+			updateItemPresentationModel(convertView, position);
+			return convertView;
+		}
+	}
 
-    private View newView(int position, ViewGroup parent, DisplayType displayType) {
-        BindableView bindableView;
-        Object item = getItem(position);
-        if (displayType == DisplayType.ITEM_LAYOUT) {
-            int layoutId = itemLayoutSelector.selectLayout(getItemViewType(position));
-            bindableView = itemLayoutBinder.inflate(parent, layoutId);
-        } else {
-            bindableView = dropdownLayoutBinder.inflate(parent, dropdownLayoutId);
-        }
+	private View newView(int position, ViewGroup parent, DisplayType displayType) {
+		BindableView bindableView;
+		Object item = getItem(position);
+		if (displayType == DisplayType.ITEM_LAYOUT) {
+			int layoutId = itemLayoutSelector.selectLayout(getItemViewType(position));
+			bindableView = itemLayoutBinder.inflate(parent, layoutId);
+		} else {
+			bindableView = dropdownLayoutBinder.inflate(parent, dropdownLayoutId);
+		}
 
-        View view = bindableView.getRootView();
-        RefreshableItemPresentationModel itemPresentationModel = dataSetValueModel.newRefreshableItemPresentationModel(
-                getItemViewType(position));
-        bindableView.bindTo((AbstractPresentationModelObject) itemPresentationModel);
-        itemPresentationModel.updateData(item, new ItemContext(view, position));
-        refreshIfRequired(itemPresentationModel);
+		View view = bindableView.getRootView();
+		RefreshableItemPresentationModel itemPresentationModel = dataSetValueModel.newRefreshableItemPresentationModel(
+				getItemViewType(position));
+		bindableView.bindTo((AbstractPresentationModelObject) itemPresentationModel);
+		itemPresentationModel.updateData(item, new ItemContext(view, position));
+		refreshIfRequired(itemPresentationModel);
 
-        ViewTag<RefreshableItemPresentationModel> viewTag = viewTags.tagFor(view);
-        viewTag.set(itemPresentationModel);
-        return view;
-    }
+		ViewTag<RefreshableItemPresentationModel> viewTag = viewTags.tagFor(view);
+		viewTag.set(itemPresentationModel);
+		return view;
+	}
 
-    private boolean isPreinitializable(RefreshableItemPresentationModel itemPresentationModel) {
-        final Class<?> presentationModelClass = ((AbstractPresentationModelObject) itemPresentationModel).getPresentationModelClass();
-        return !presentationModelClass.isAnnotationPresent(DoNotPreinitialize.class);
-    }
+	private boolean isPreinitializable(RefreshableItemPresentationModel itemPresentationModel) {
+		final Class<?> presentationModelClass = ((AbstractPresentationModelObject) itemPresentationModel).getPresentationModelClass();
+		return !presentationModelClass.isAnnotationPresent(DoNotPreinitialize.class);
+	}
 
-    private void updateItemPresentationModel(View view, int position) {
-        ViewTag<RefreshableItemPresentationModel> viewTag = viewTags.tagFor(view);
-        RefreshableItemPresentationModel itemPresentationModel = viewTag.get();
-        itemPresentationModel.updateData(getItem(position), new ItemContext(view, position));
-        refreshIfRequired(itemPresentationModel);
-    }
+	private void updateItemPresentationModel(View view, int position) {
+		ViewTag<RefreshableItemPresentationModel> viewTag = viewTags.tagFor(view);
+		RefreshableItemPresentationModel itemPresentationModel = viewTag.get();
+		itemPresentationModel.updateData(getItem(position), new ItemContext(view, position));
+		refreshIfRequired(itemPresentationModel);
+	}
 
-    private void refreshIfRequired(RefreshableItemPresentationModel itemPresentationModel) {
-        if (isPreinitializable(itemPresentationModel)) {
-            itemPresentationModel.refresh();
-        }
-    }
+	private void refreshIfRequired(RefreshableItemPresentationModel itemPresentationModel) {
+		if (isPreinitializable(itemPresentationModel)) {
+			itemPresentationModel.refresh();
+		}
+	}
 
-    @Override
-    public int getViewTypeCount() {
-        return itemLayoutSelector.getViewTypeCount();
-    }
+	@Override
+	public int getViewTypeCount() {
+		return itemLayoutSelector.getViewTypeCount();
+	}
 
-    @Override
-    public int getItemViewType(int position) {
-        return itemLayoutSelector.getItemViewType(getItem(position), position);
-    }
+	@Override
+	public int getItemViewType(int position) {
+		return itemLayoutSelector.getItemViewType(getItem(position), position);
+	}
 }

--- a/framework/src/main/java/org/robobinding/widget/adapterview/DataSetAdapterBuilder.java
+++ b/framework/src/main/java/org/robobinding/widget/adapterview/DataSetAdapterBuilder.java
@@ -88,8 +88,8 @@ public class DataSetAdapterBuilder implements RequiresItemLayoutId, RequiresItem
 		DataSetAdapter dataSetAdapter = new DataSetAdapter(
 				valueModelWithPreInitializeViews(valueModel, bindingContext.shouldPreInitializeViews()),
 				itemLayoutBinder, dropdownLayoutBinder, itemLayoutSelector, dropdownLayoutId,
-				new ViewTags<RefreshableItemPresentationModel>(ITEM_PRESENTATION_MODEL_KEY), 
-				bindingContext.shouldPreInitializeViews());
+				new ViewTags<RefreshableItemPresentationModel>(ITEM_PRESENTATION_MODEL_KEY)
+		);
 
 		registerPropertyChangeListener(dataSetAdapter);
 		return dataSetAdapter;

--- a/framework/src/test/java/org/robobinding/widget/adapterview/DataSetAdapterTest.java
+++ b/framework/src/test/java/org/robobinding/widget/adapterview/DataSetAdapterTest.java
@@ -219,7 +219,7 @@ public class DataSetAdapterTest {
 		public DataSetAdapter build() {
 			return new DataSetAdapter(valueModel, itemLayoutBinder, 
 					dropdownLayoutBinder, layoutSelector, dropdownLayoutId,
-					viewTags, preInitializeViews);
+					viewTags);
 		}
 	}
 }


### PR DESCRIPTION
Fix to the problem described in issue #238 - when layout with adapter view was inflated with delayed initialization (preinitialize=false), item views were not initialized until reuse.

This change fixes the problem and sets item view preinitialization as default policy. Developer can change this behavior on ItemPresentationModel impl level using @DoNotPreinitialize annotation.